### PR TITLE
Must throws error when using synchronous mode

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -314,7 +314,7 @@ exports.XMLHttpRequest = function () {
       if (settings.async) {
         fs.readFile(url, 'utf8', function (error, data) {
           if (error) {
-            self.handleError(error)
+            self.handleError(error, url)
           } else {
             self.status = 200
             self.responseText = data
@@ -327,7 +327,7 @@ exports.XMLHttpRequest = function () {
           this.status = 200
           setState(self.DONE)
         } catch (e) {
-          this.handleError(e)
+          this.handleError(e, url)
         }
       }
 
@@ -488,13 +488,13 @@ exports.XMLHttpRequest = function () {
         }
 
         response.on('error', function (error) {
-          self.handleError(error)
+          self.handleError(error, url)
         })
       }
 
       // Error handler for the request
       const errorHandler = function errorHandler (error) {
-        self.handleError(error)
+        self.handleError(error, url)
       }
 
       // Create the request
@@ -517,20 +517,7 @@ exports.XMLHttpRequest = function () {
 --request-options=${JSON.stringify(JSON.stringify(options))}`, { stdio: ['pipe', 'pipe', 'pipe'], input: data })
       const result = JSON.parse(output.toString('utf8'))
       if (result.error) {
-        // DNS failure
-        if (result.error.code === 'ENOTFOUND' || result.error.code === 'EAI_AGAIN') {
-          // XMLHttpRequest throws a DOMException when DNS lookup fails:
-          // code: 19
-          // message: "Failed to execute 'send' on 'XMLHttpRequest': Failed to load 'http://url/'."
-          // name: "NetworkError"
-          // stack: (...)
-          throw new Error(`Failed to execute 'send' on 'XMLHttpRequest': Failed to load '${url}'.`)
-        }
-        if (typeof result.error === 'object') {
-          throw new Error(JSON.stringify(result.error))
-        } else {
-          throw new Error(result.error)
-        }
+        throw translateError(result.error, url)
       } else {
         response = result.data
         self.status = result.data.statusCode
@@ -547,13 +534,13 @@ exports.XMLHttpRequest = function () {
   /**
    * Called when an error is encountered to deal with it.
    */
-  this.handleError = function (error) {
+  this.handleError = function (error, url) {
     this.status = 0
     this.statusText = ''
     this.responseText = ''
     errorFlag = true
     setState(this.DONE)
-    this.dispatchEvent('error', { error })
+    this.dispatchEvent('error', { error: translateError(error, url) })
   }
 
   /**
@@ -639,5 +626,23 @@ exports.XMLHttpRequest = function () {
         self.dispatchEvent('loadend')
       }
     }
+  }
+
+  const translateError = function (error, url) {
+    if (typeof error === 'object') {
+      if (error.code === 'ENOTFOUND' || error.code === 'EAI_AGAIN') {
+        // XMLHttpRequest throws a DOMException when DNS lookup fails:
+        // code: 19
+        // message: "Failed to execute 'send' on 'XMLHttpRequest': Failed to load 'http://url/'."
+        // name: "NetworkError"
+        // stack: (...)
+        return new Error(`Failed to execute 'send' on 'XMLHttpRequest': Failed to load '${url}'.`)
+      }
+      if (error instanceof Error) {
+        return error
+      }
+      return new Error(JSON.stringify(error))
+    }
+    return new Error(error)
   }
 }

--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -517,7 +517,20 @@ exports.XMLHttpRequest = function () {
 --request-options=${JSON.stringify(JSON.stringify(options))}`, { stdio: ['pipe', 'pipe', 'pipe'], input: data })
       const result = JSON.parse(output.toString('utf8'))
       if (result.error) {
-        self.handleError(result.error)
+        // DNS failure
+        if (result.error.code === 'ENOTFOUND' || result.error.code === 'EAI_AGAIN') {
+          // XMLHttpRequest throws a DOMException when DNS lookup fails:
+          // code: 19
+          // message: "Failed to execute 'send' on 'XMLHttpRequest': Failed to load 'http://url/'."
+          // name: "NetworkError"
+          // stack: (...)
+          throw new Error(`Failed to execute 'send' on 'XMLHttpRequest': Failed to load '${url}'.`)
+        }
+        if (typeof result.error === 'object') {
+          throw new Error(JSON.stringify(result.error))
+        } else {
+          throw new Error(result.error)
+        }
       } else {
         response = result.data
         self.status = result.data.statusCode

--- a/lib/request.js
+++ b/lib/request.js
@@ -83,8 +83,12 @@ function doRequest (options, data) {
         }
       })
       process.stdin.on('end', async function () {
-        const result = await doRequest(options, data)
-        console.log(JSON.stringify(result))
+        try {
+          const result = await doRequest(options, data)
+          console.log(JSON.stringify(result))
+        } catch (e) {
+          console.log(JSON.stringify({ error: e }))
+        }
       })
     }
   } catch (e) {

--- a/tests/test-exceptions.js
+++ b/tests/test-exceptions.js
@@ -59,11 +59,14 @@ describe('XMLHttpRequest exceptions', () => {
   if (osplatform !== 'win32') {
     it('should throw an exception on DNS resolution failure (sync)', () => {
       const url = 'http://nodns/'
-      expect(() => {
+      try {
         const xhr = new XMLHttpRequest()
         xhr.open('GET', url, false)
         xhr.send()
-      }).to.throw('Failed to execute \'send\' on \'XMLHttpRequest\': Failed to load \'http://nodns/\'.')
+        expect.fail('Request should not succeed!')
+      } catch (err) {
+        expect(err.message).to.equal('Failed to execute \'send\' on \'XMLHttpRequest\': Failed to load \'http://nodns/\'.')
+      }
     })
     it('should throw an exception on DNS resolution failure (async)', async () => {
       const url = 'http://nodns/'
@@ -76,15 +79,14 @@ describe('XMLHttpRequest exceptions', () => {
               resolve({})
             }
           }
-          xhr.onerror = function () {
-            // responseText and response should be empty
-            reject(new Error('Error while executing the query'))
+          xhr.onerror = function (e) {
+            reject(e.error)
           }
           xhr.send()
         })
-        expect.fail('should throw an exception on DNS resolution failure')
+        expect.fail('Request should not succeed!')
       } catch (err) {
-        expect(err.message).to.equal('Error while executing the query')
+        expect(err.message).to.equal('Failed to execute \'send\' on \'XMLHttpRequest\': Failed to load \'http://nodns/\'.')
       }
     })
   }

--- a/tests/test-exceptions.js
+++ b/tests/test-exceptions.js
@@ -1,7 +1,9 @@
 const chai = require('chai')
 const dirtyChai = require('dirty-chai')
+const os = require('os')
 chai.use(dirtyChai)
 const expect = chai.expect
+const osplatform = os.platform()
 const XMLHttpRequest = require('../lib/XMLHttpRequest').XMLHttpRequest
 const xhr = new XMLHttpRequest()
 
@@ -53,6 +55,39 @@ describe('XMLHttpRequest exceptions', () => {
     xhr.setRequestHeader('X-Foobar', 'Test')
     expect(xhr.getRequestHeader('X-Foobar')).to.equal('Test')
   })
+  // Windows has a "long" timeout (> 2s) on DNS resolution
+  if (osplatform !== 'win32') {
+    it('should throw an exception on DNS resolution failure (sync)', () => {
+      const url = 'http://nodns/'
+      expect(() => {
+        const xhr = new XMLHttpRequest()
+        xhr.open('GET', url, false)
+        xhr.send()
+      }).to.throw('Failed to execute \'send\' on \'XMLHttpRequest\': Failed to load \'http://nodns/\'.')
+    })
+    it('should throw an exception on DNS resolution failure (async)', async () => {
+      const url = 'http://nodns/'
+      const xhr = new XMLHttpRequest()
+      try {
+        await new Promise((resolve, reject) => {
+          xhr.open('GET', url, true)
+          xhr.onload = function () {
+            if (xhr.readyState === 4) {
+              resolve({})
+            }
+          }
+          xhr.onerror = function () {
+            // responseText and response should be empty
+            reject(new Error('Error while executing the query'))
+          }
+          xhr.send()
+        })
+        expect.fail('should throw an exception on DNS resolution failure')
+      } catch (err) {
+        expect(err.message).to.equal('Error while executing the query')
+      }
+    })
+  }
 })
 
 /*


### PR DESCRIPTION
Original work by @djencks

In the browser, the following code will throw an exception:

```js
try { 
  const xhr = new XMLHttpRequest();
  xhr.open('GET', `http://nodns`, false); 
  xhr.send();
} catch(e) {
  console.log({e})
}
```

The error is a [`DOMException`](https://developer.mozilla.org/fr/docs/Web/API/DOMException) (which is not available in a Node environment) with the following information:

```
code: 19
message: "Failed to execute 'send' on 'XMLHttpRequest': Failed to load 'http://nodns/'."
name: "NetworkError"
stack: (...)
```

I've added a special case to create a similar exception when Node throws a `ENOTFOUND` from [`dns.lookup`](https://nodejs.org/api/dns.html#dns_dns_lookup_hostname_options_callback).