### PR TITLE
Fix to work in VS Code context

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -517,10 +517,9 @@ exports.XMLHttpRequest = function () {
         : DEFAULT_MAX_BUFFER
       const encoding = responseType === 'text' ? 'utf8' : 'binary'
       const scriptPath = ospath.join(__dirname, 'request.js')
-      const output = require('child_process').execSync(`"${process.execPath}" "${scriptPath}" \
---ssl="${ssl}" \
---encoding="${encoding}" \
---request-options=${JSON.stringify(JSON.stringify(options))}`, { stdio: ['pipe', 'pipe', 'pipe'], input: data, maxBuffer: maxBuffer })
+      const output = require('child_process').execFileSync(scriptPath,
+        [`--ssl="${ssl}"`, `--encoding="${encoding}"`, `--request-options=${JSON.stringify(JSON.stringify(options))}`],
+        { stdio: ['pipe', 'pipe', 'pipe'], input: data, maxBuffer: maxBuffer })
       const result = JSON.parse(output.toString('utf8'))
       if (result.error) {
         throw translateError(result.error, url)


### PR DESCRIPTION
it avoids to rely on `process.execPath` which resolves to `code` binary in VS Code context although it expects the `node` binary

relates to asciidoctor/asciidoctor-vscode#731